### PR TITLE
Fix for issue-28 "Type Error" when port parameter is not passed while calling setup_db

### DIFF
--- a/wikilink/wiki_link.py
+++ b/wikilink/wiki_link.py
@@ -38,7 +38,7 @@ class WikiLink:
 	def __init__(self):
 		pass
 
-	def setup_db(self, db, name, password, ip="127.0.0.1", port=3306):
+	def setup_db(self, db, name, password, ip="127.0.0.1", port="3306"):
 
 		""" Setting up database
 		Args:


### PR DESCRIPTION
This is fix for issue#28 , when port parameter is not passed, the default value is of type int. So made the default value type string